### PR TITLE
Remove a debugging Serial.print()

### DIFF
--- a/src/Kaleidoscope/EEPROM-Settings.cpp
+++ b/src/Kaleidoscope/EEPROM-Settings.cpp
@@ -62,9 +62,6 @@ uint16_t EEPROMSettings::requestSlice(uint16_t size) {
   if (sealed_)
     return 0;
 
-  Serial.print("requestSlice; size=");
-  Serial.println(size);
-
   uint16_t start = next_start_;
   next_start_ += size;
 


### PR DESCRIPTION
These two lines went in by mistake earlier, they were meant for local debugging only. As such, having them in the plugin is a bug, easily squashed by removing them.
