### PR TITLE
Seal the EEPROM layout automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 > Seal the `EEPROM` layout, so no new slices can be requested. The CRC checksum
 > is considered final at this time, and the `isValid()`, `crc()`, `used()` and
 > `version()` methods can be used from this point onwards.
+>
+> If not called explicitly, the layout will be sealed automatically after
+> `setup()` in the sketch finished.
 
 ### `update()`
 

--- a/src/Kaleidoscope/EEPROM-Settings.cpp
+++ b/src/Kaleidoscope/EEPROM-Settings.cpp
@@ -30,6 +30,13 @@ EventHandlerResult EEPROMSettings::onSetup() {
   return EventHandlerResult::OK;
 }
 
+EventHandlerResult EEPROMSettings::beforeEachCycle() {
+  if (!sealed_)
+    seal();
+
+  return EventHandlerResult::OK;
+}
+
 bool EEPROMSettings::isValid(void) {
   return is_valid_;
 }

--- a/src/Kaleidoscope/EEPROM-Settings.h
+++ b/src/Kaleidoscope/EEPROM-Settings.h
@@ -26,6 +26,7 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   EEPROMSettings(void) {}
 
   EventHandlerResult onSetup();
+  EventHandlerResult beforeEachCycle();
 
   static void update(void);
   static bool isValid(void);


### PR DESCRIPTION
If `EEPROMSettings.seal()` wasn't explicitly called, seal the layout in `beforeEachCycle()`. On the flip side, this makes user sketches simpler, because they don't have to seal explicitly. This is done at the cost of an if check each cycle.

In the long run, EEPROM layout management will be moving out of this plugin, so this check will be eventually dropped too.
