### PR TITLE
Migrate to the new onFocusEvent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,12 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 
 ## Focus commands
 
-The plugin provides two [Focus][focus] hooks: `FOCUS_HOOK_SETTINGS`, and
-`FOCUS_HOOK_EEPROM`, that register commands that allow one to work with the
-settings, and with the contents of the `EEPROM` through Focus.
+The plugin provides two - optional - [Focus][FocusSerial] command plugins:
+`FocusSettingsCommand` and `FocusEEPROMCommand`. These must be explicitly added
+to `KALEIDOSCOPE_INIT_PLUGINS` if one wishes to use them. They provide the
+following commands:
 
- [focus]: https://github.com/keyboardio/Kaleidoscope-Focus
-
-These provide the following `Focus` commands:
+ [FocusSerial]: https://github.com/keyboardio/Kaleidoscope-FocusSerial
 
 ### `settings.crc`
 
@@ -153,7 +152,7 @@ These provide the following `Focus` commands:
 
 ## Dependencies
 
-* [Kaleidoscope-Focus][focus]
+* [Kaleidoscope-FocusSerial][FocusSerial]
 
 ## Further reading
 

--- a/src/Kaleidoscope/EEPROM-Settings-Focus.h
+++ b/src/Kaleidoscope/EEPROM-Settings-Focus.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Settings -- Basic EEPROM settings plugin for Kaleidoscope.
- * Copyright (C) 2017  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,21 +20,23 @@
 #include <Kaleidoscope.h>
 
 namespace kaleidoscope {
-namespace eeprom_settings {
+namespace eeprom {
+class FocusSettingsCommand : public kaleidoscope::Plugin {
+ public:
+  FocusSettingsCommand() {}
 
-bool settingsFocusHook(const char *command);
-bool eepromFocusHook(const char *command);
+  EventHandlerResult onFocusEvent(const char *command);
+};
+
+class FocusEEPROMCommand : public kaleidoscope::Plugin {
+ public:
+  FocusEEPROMCommand () {}
+
+  EventHandlerResult onFocusEvent(const char *command);
+};
 
 }
 }
 
-#define FOCUS_HOOK_SETTINGS FOCUS_HOOK                                  \
-  (kaleidoscope::eeprom_settings::settingsFocusHook,                    \
-   "settings.valid?\n"                                                  \
-   "settings.version\n"                                                 \
-   "settings.crc")
-
-#define FOCUS_HOOK_EEPROM FOCUS_HOOK                                    \
-  (kaleidoscope::eeprom_settings::eepromFocusHook,                      \
-   "eeprom.free\n"                                                      \
-   "eeprom.contents")
+extern kaleidoscope::eeprom::FocusSettingsCommand FocusSettingsCommand;
+extern kaleidoscope::eeprom::FocusEEPROMCommand FocusEEPROMCommand;


### PR DESCRIPTION
Depends on keyboardio/Kaleidoscope#362 and keyboardio/Kaleidoscope-Bundle-Keyboardio#3.