### PR TITLE
Clean up the EEPROM header

### DIFF
--- a/src/Kaleidoscope/EEPROM-Settings.cpp
+++ b/src/Kaleidoscope/EEPROM-Settings.cpp
@@ -52,12 +52,11 @@ void EEPROMSettings::seal(void) {
 
   CRC.finalize();
 
-  if (settings_.magic[0] != 'K' || settings_.magic[1] != 'S') {
-    settings_.magic[0] = 'K';
-    settings_.magic[1] = 'S';
-    settings_.version = 0;
-    settings_.crc = CRC.crc;
-
+  /* Until we set a version, consider the EEPROM contents flexible, and always
+   * update the CRC. This will always result in the settings being considered
+   * valid.
+   */
+  if (settings_.version == 0xff) {
     return update();
   }
 

--- a/src/Kaleidoscope/EEPROM-Settings.h
+++ b/src/Kaleidoscope/EEPROM-Settings.h
@@ -45,7 +45,6 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   static bool sealed_;
 
   static struct settings {
-    char magic[2];
     uint8_t version;
     uint16_t crc;
   } settings_;


### PR DESCRIPTION
This removes the `magic` field from the beginning of the header. It was originally meant to signal if the EEPROM we're dealing with is new, or if it has been set up with `EEPROMSettings` before. But as `EEPROMSettings` is pretty much the only way we deal with EEPROM, there's not much need for that.

With the removal, we do need a way to update the CRC bits on first use, so we use the `version` field instead: if it is `0xff`, we update the CRC, and consider the settings valid. This means that until the version is set, the EEPROM layout is considered flexible, and verification is essentially disabled.

Once the version is set, we can validate.