### PR TITLE
Add support for saving the default layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 >
 > Should only be called **before** calling `seal()`.
 
+### `default_layer([id])`
+
+> Sets (or returns, if called without an ID) the default layer. When the
+> keyboard boots up, it will automatically switch to the configured layer - if
+> any.
+>
+> This is the Focus counterpart of the `default_layer()` method documented
+> above.
+
 ### `seal()`
 
 > Seal the `EEPROM` layout, so no new slices can be requested. The CRC checksum
@@ -124,6 +133,12 @@ to `KALEIDOSCOPE_INIT_PLUGINS` if one wishes to use them. They provide the
 following commands:
 
  [FocusSerial]: https://github.com/keyboardio/Kaleidoscope-FocusSerial
+
+### `settings.defaultLayer`
+
+> Sets or returns (if called without arguments) the ID of the default layer. If
+> set, the keyboard will automatically switch to the given layer when connected.
+> Setting it to `255` disables the automatic switching.
 
 ### `settings.crc`
 

--- a/src/Kaleidoscope/EEPROM-Settings-Focus.cpp
+++ b/src/Kaleidoscope/EEPROM-Settings-Focus.cpp
@@ -24,32 +24,43 @@ namespace eeprom {
 
 EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
   enum {
-    ISVALID,
-    GETVERSION,
+    DEFAULT_LAYER,
+    IS_VALID,
+    GET_VERSION,
     CRC,
   } sub_command;
 
-  if (::Focus.handleHelp(command, PSTR("settings.valid?\nsettings.version\nsettings.crc")))
+  if (::Focus.handleHelp(command, PSTR("settings.defaultLayer\nsettings.valid?\nsettings.version\nsettings.crc")))
     return EventHandlerResult::OK;
 
   if (strncmp_P(command, PSTR("settings."), 9) != 0)
     return EventHandlerResult::OK;
 
-  if (strcmp_P(command + 9, PSTR("valid?")) == 0)
-    sub_command = ISVALID;
+  if (strcmp_P(command + 9, PSTR("defaultLayer")) == 0)
+    sub_command = DEFAULT_LAYER;
+  else if (strcmp_P(command + 9, PSTR("valid?")) == 0)
+    sub_command = IS_VALID;
   else if (strcmp_P(command + 9, PSTR("version")) == 0)
-    sub_command = GETVERSION;
+    sub_command = GET_VERSION;
   else if (strcmp_P(command + 9, PSTR("crc")) == 0)
     sub_command = CRC;
   else
     return EventHandlerResult::OK;
 
   switch (sub_command) {
-  case ISVALID:
+  case DEFAULT_LAYER: {
+    if (Serial.peek() == '\n') {
+      Serial.println(::EEPROMSettings.default_layer());
+    } else {
+      ::EEPROMSettings.default_layer(Serial.parseInt());
+    }
+    break;
+  }
+  case IS_VALID:
     ::Focus.printBool(::EEPROMSettings.isValid());
     Serial.println();
     break;
-  case GETVERSION:
+  case GET_VERSION:
     Serial.println(::EEPROMSettings.version());
     break;
   case CRC:

--- a/src/Kaleidoscope/EEPROM-Settings.cpp
+++ b/src/Kaleidoscope/EEPROM-Settings.cpp
@@ -47,15 +47,28 @@ uint16_t EEPROMSettings::crc(void) {
   return 0;
 }
 
+uint8_t EEPROMSettings::default_layer(uint8_t layer) {
+  if (layer == 0xff)
+    return settings_.default_layer;
+
+  settings_.default_layer = layer;
+  update();
+  return settings_.default_layer;
+}
+
 void EEPROMSettings::seal(void) {
   sealed_ = true;
 
   CRC.finalize();
 
+  /* If we have a default layer set, switch to it. As 0xff is the default EEPROM
+   * value, treat it as not having a default layer set. */
+  if (settings_.default_layer != 0xff)
+    Layer.move(settings_.default_layer);
+
   /* Until we set a version, consider the EEPROM contents flexible, and always
    * update the CRC. This will always result in the settings being considered
-   * valid.
-   */
+   * valid. */
   if (settings_.version == 0xff) {
     return update();
   }

--- a/src/Kaleidoscope/EEPROM-Settings.h
+++ b/src/Kaleidoscope/EEPROM-Settings.h
@@ -39,12 +39,15 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   static uint16_t crc(void);
   static uint16_t used(void);
 
+  static uint8_t default_layer(uint8_t layer = 0xff);
+
  private:
   static uint16_t next_start_;
   static bool is_valid_;
   static bool sealed_;
 
   static struct settings {
+    uint8_t default_layer;
     uint8_t version;
     uint16_t crc;
   } settings_;


### PR DESCRIPTION
With upcoming EEPROMKeymap changes, saving the default layer will become an important part of the keyboard settings. The new `default_layer` method provides a way to set it programmatically, while the `settings.defaultLayer` Focus command allows the user to set it via Focus.

The default layer - if set - is activated when the settings are sealed, either directly or automatically.